### PR TITLE
Firecrawl follow-up: discoverability + lighting-pro registry alignment

### DIFF
--- a/CAPABILITY_REGISTRY.md
+++ b/CAPABILITY_REGISTRY.md
@@ -16,6 +16,7 @@ Single source of truth for what's available and where to find it.
 | Electrical Guru | `capabilities/electrical-guru/` | 1 | 1 | 0 | 0 | Active |
 | File Steward | `capabilities/file-steward/` | 3 | 0 | 1 | 0 | Active |
 | Firecrawl | `capabilities/firecrawl/` | 0 | 1 | 0 | 0 | Active |
+| Lighting Pro | `capabilities/lighting-pro/` | 1 | 1 | 0 | 0 | Active |
 | Phoenix Comms | `capabilities/phoenix-comms/` | 5 | 0 | 0 | 3 | Active |
 | Phoenix Knowledge | `capabilities/phoenix-knowledge/` | 1 | 1 | 1 | 0 | Active |
 | Rexel | `capabilities/rexel/` | 4 | 1 | 1 | 0 | Active |
@@ -25,7 +26,7 @@ Single source of truth for what's available and where to find it.
 | Phoenix 365 | `capabilities/phoenix-365/` | 4 | 3 | 2 | 1 | Active |
 | Browser Persistence | `capabilities/browser-persistence/` | 0 | 4 | 0 | 0 | Active — Doc-based Persistence |
 
-**Totals:** 12 capabilities, 32 commands, 14 skills, 11 agents, 7 hook definitions
+**Totals:** 13 capabilities, 33 commands, 15 skills, 11 agents, 7 hook definitions
 
 > **Hook counting standard:** Hooks = number of event handler definitions that fire at runtime.
 > > Empty hooks.json config files (Rexel, ServiceFusion) count as 0.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This repo follows a **capability-first architecture**: every functional unit liv
 | **Phoenix 365** | `capabilities/phoenix-365/` | 4 | 3 | 2 | 1 | Active |
 | **File Steward** | `capabilities/file-steward/` | 3 | 0 | 1 | 0 | Active |
 | **Electrical Guru** | `capabilities/electrical-guru/` | 1 | 1 | 0 | 0 | Active |
+| **Lighting Pro** | `capabilities/lighting-pro/` | 1 | 1 | 0 | 0 | Active |
 | **Phoenix Knowledge** | `capabilities/phoenix-knowledge/` | 1 | 1 | 1 | 0 | Active |
 | **Volt Marketing** | `capabilities/volt-marketing/` | 1 | 1 | 0 | 0 | Active |
 | **Firecrawl** | `capabilities/firecrawl/` | — | 1 | — | — | Active — Doc-based |
@@ -59,10 +60,11 @@ See [CAPABILITY_REGISTRY.md](CAPABILITY_REGISTRY.md) for the full registry with 
 
 ```
 phoenix-toolbox/
-├── capabilities/              # All capabilities (11 total)
+├── capabilities/              # All capabilities (13 total)
 │   ├── echo-persistence/      # Identity, logging, session survival
 │   ├── electrical-guru/       # NEC 2023 code consultant
 │   ├── file-steward/          # File management and triage
+│   ├── lighting-pro/          # Lighting controls, DMX, LED, NEC 2023 compliance
 │   ├── phoenix-comms/         # Cross-agent heartbeat protocol
 │   ├── phoenix-knowledge/     # Phoenix Electric knowledge base
 │   ├── rexel/                 # Vendor pricing and purchase history
@@ -70,7 +72,7 @@ phoenix-toolbox/
 │   ├── volt-marketing/        # Marketing strategist + MCP server
 │   ├── gauntlet/              # Multi-agent terminal dashboard (standalone)
 │   ├── phoenix-365/           # Microsoft 365 integration
-│   ├── firecrawl/             # Web research / scraping playbook (doc-based)
+│   ├── firecrawl/             # Web research / scraping playbook
 │   └── browser-persistence/   # Browser session persistence (doc-based)
 ├── mcp-servers/               # Shared MCP servers
 │   ├── builder-mcp/           # Multi-module Azure Functions platform

--- a/capabilities/firecrawl/.claude-plugin/plugin.json
+++ b/capabilities/firecrawl/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "firecrawl",
+  "version": "1.0.0",
+  "description": "Firecrawl web research and structured-extraction playbook. Auto-activates on web scraping, crawling, pricing tracking, competitor analysis, SEC filings, and product/SKU extraction tasks. Bundles deep-research, structured-extraction, pricing-tracker, competitor-analysis, financial-research, and e-commerce sub-playbooks adapted from the open-source firecrawl/web-agent reference implementation (MIT).",
+  "author": {
+    "name": "Shane Warehime",
+    "email": "shane@phoenixelectric.life"
+  },
+  "repository": "https://github.com/GIT-PHOENIX-HUB/phoenix-toolbox",
+  "license": "PROPRIETARY",
+  "keywords": ["firecrawl", "web-scraping", "research", "extraction", "pricing", "competitor-analysis", "phoenix-electric"]
+}

--- a/capabilities/firecrawl/README.md
+++ b/capabilities/firecrawl/README.md
@@ -52,7 +52,7 @@ Firecrawl requires an API key (`FIRECRAWL_API_KEY` / `fc-...`). Per Phoenix poli
 
 ## Installation
 
-Symlink or copy this folder to `~/.claude/plugins/firecrawl/`:
+This capability ships with `.claude-plugin/plugin.json` so Claude Code discovers it automatically on plugin-directory scan. Symlink or copy this folder to `~/.claude/plugins/firecrawl/`:
 
 ```bash
 ln -s /path/to/capabilities/firecrawl ~/.claude/plugins/firecrawl

--- a/capabilities/firecrawl/skills/firecrawl/SKILL.md
+++ b/capabilities/firecrawl/skills/firecrawl/SKILL.md
@@ -100,8 +100,9 @@ The skill bundles six task-specific playbooks. Pick the one that matches the use
 - Use `null` for missing fields — never omit keys.
 - Arrays must be arrays even for single items.
 - Numbers must be numbers, not strings: `10.99`, not `"$10.99"`.
-- Use `bashExec` with `jq` to merge data from multiple sources where available:
+- Use the `Bash` tool with `jq` to merge data from multiple sources where available:
   `jq -s '.[0] * .[1]' /data/part1.json /data/part2.json > /data/merged.json`
+  (If you are running inside the upstream firecrawl/web-agent runtime instead of Claude Code, the equivalent tool is `bashExec` powered by `just-bash`.)
 - Validate before emitting: required fields present, types correct, no array duplicates, source URLs included.
 
 ### 3. Pricing Tracker


### PR DESCRIPTION
## Summary

Follow-up to PR #8 / #9 (which landed the Firecrawl capability) — applies the five stranded Copilot-review fixes that never made it into the merged commit.

The merged Firecrawl PR left `main` in an inconsistent state:

- Root `README.md` totals said "13 capabilities. 33 commands. 15 skills." but the inventory table only listed 12 rows (lighting-pro missing) and the directory tree still said `(11 total)`.
- `CAPABILITY_REGISTRY.md` totals read 12/32/14 with lighting-pro missing from the rows.
- `capabilities/firecrawl/` shipped with no `.claude-plugin/plugin.json`, so Claude Code does not discover it when symlinked.
- `capabilities/firecrawl/skills/firecrawl/SKILL.md` referenced `bashExec` as if it were a Claude Code tool.

This PR cherry-picks commit `0bfab07` (originally pushed to PR #8's branch but not included in the merged commit) onto a fresh branch off `main`. Cherry-pick was clean — no conflicts.

## Changes (5 files)

- **NEW** `capabilities/firecrawl/.claude-plugin/plugin.json` — makes the capability discoverable via the standard plugin scan path
- `capabilities/firecrawl/README.md` — install section now mentions the manifest ships with the capability
- `capabilities/firecrawl/skills/firecrawl/SKILL.md` — `bashExec` → `Bash` for the jq-merge example, with an explanatory note that `bashExec` is the equivalent in the upstream firecrawl/web-agent runtime
- `README.md` — adds the missing `Lighting Pro` row to the inventory table, adds `lighting-pro/` to the directory tree, updates `(11 total)` → `(13 total)`
- `CAPABILITY_REGISTRY.md` — adds the missing `Lighting Pro` row, bumps totals from 12/32/14 to 13/33/15

## Verification gates (all passing locally)

- [x] README totals + inventory table agree at 13 capabilities / 33 commands / 15 skills
- [x] README directory tree comment says `(13 total)`
- [x] CAPABILITY_REGISTRY totals + rows agree
- [x] `lighting-pro` appears in both root README and CAPABILITY_REGISTRY
- [x] `capabilities/firecrawl/.claude-plugin/plugin.json` exists
- [x] `bashExec` only appears as an explicit "upstream equivalent" explanatory note, never as a claimed Claude Code tool

## Test plan

- [ ] Confirm `~/.claude/plugins/firecrawl/` symlink now triggers plugin discovery (capability shows up in Claude Code's plugin list)
- [ ] Confirm the skill auto-activates on a pricing-tracker / competitor-analysis prompt
- [ ] Once merged, delete the stale branch `claude/add-firecrawl-skill-bDk0m`

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpQiNZNijCrrPsQ6B642cc)_